### PR TITLE
fix: Throw exception in tictoc web

### DIFF
--- a/packages/tictoc/lib/src/tictoc_web/tictoc_web.dart
+++ b/packages/tictoc/lib/src/tictoc_web/tictoc_web.dart
@@ -27,13 +27,13 @@ class TicToc implements TicTocInterface {
   Future<Timestamp> sync() async {
     final LocationTime? locationTime =
         await EasyNetworkTime.getTimeNetwork(TimeLocation.asiaSeoul);
-    // TODO(team): throw `locationTime is not allowed to be null` 할지 말지 결정
-    if (locationTime != null) {
-      final DateTime networkDateTime = locationTime.dateTime;
-      worldTimeApiOffset =
-          networkDateTime.difference(DateTime.now()).inMilliseconds;
-      _synced = true;
+    if (locationTime == null) {
+      throw Exception('locationTime is not allowed to be null');
     }
+    final DateTime networkDateTime = locationTime.dateTime;
+    worldTimeApiOffset =
+        networkDateTime.difference(DateTime.now()).inMilliseconds;
+    _synced = true;
     return now();
   }
 


### PR DESCRIPTION
## tictoc web에서 locationTime이 null이면 exception을 throw합니다
- locationTime을 가져오는데 실패했을 때 localTime을 반환하는 것이 부자연스럽다고 판단했습니다!