### PR TITLE
fix: Unify `offset` in TicToc

### DIFF
--- a/packages/tictoc/lib/src/tictoc_native/tictoc_native.dart
+++ b/packages/tictoc/lib/src/tictoc_native/tictoc_native.dart
@@ -12,19 +12,19 @@ class TicToc implements TicTocInterface {
 
   static final TicToc instance = TicToc.instantiate();
 
-  int ntpOffset = 0;
+  int offset = 0;
   bool _synced = false;
 
   @override
   Timestamp now([DateTime? localTime]) {
     final DateTime now = localTime ?? DateTime.now();
-    final DateTime networkTime = now.add(Duration(milliseconds: ntpOffset));
+    final DateTime networkTime = now.add(Duration(milliseconds: offset));
     return Timestamp.fromDateTime(networkTime);
   }
 
   @override
   Future<Timestamp> sync([DateTime? localTime]) async {
-    ntpOffset = await NTP.getNtpOffset();
+    offset = await NTP.getNtpOffset();
     _synced = true;
     return now(localTime);
   }

--- a/packages/tictoc/lib/src/tictoc_web/tictoc_web.dart
+++ b/packages/tictoc/lib/src/tictoc_web/tictoc_web.dart
@@ -12,14 +12,14 @@ class TicToc implements TicTocInterface {
 
   static final TicToc instance = TicToc.instantiate();
 
-  int worldTimeApiOffset = 0;
+  int offset = 0;
   bool _synced = false;
 
   @override
   Timestamp now([DateTime? localTime]) {
     final DateTime now = localTime ?? DateTime.now();
     final DateTime networkTime =
-        now.add(Duration(milliseconds: worldTimeApiOffset));
+        now.add(Duration(milliseconds: offset));
     return Timestamp.fromDateTime(networkTime);
   }
 
@@ -31,7 +31,7 @@ class TicToc implements TicTocInterface {
       throw Exception('locationTime is not allowed to be null');
     }
     final DateTime networkDateTime = locationTime.dateTime;
-    worldTimeApiOffset =
+    offset =
         networkDateTime.difference(DateTime.now()).inMilliseconds;
     _synced = true;
 

--- a/packages/tictoc/lib/src/tictoc_web/tictoc_web.dart
+++ b/packages/tictoc/lib/src/tictoc_web/tictoc_web.dart
@@ -18,8 +18,7 @@ class TicToc implements TicTocInterface {
   @override
   Timestamp now([DateTime? localTime]) {
     final DateTime now = localTime ?? DateTime.now();
-    final DateTime networkTime =
-        now.add(Duration(milliseconds: offset));
+    final DateTime networkTime = now.add(Duration(milliseconds: offset));
     return Timestamp.fromDateTime(networkTime);
   }
 
@@ -31,8 +30,7 @@ class TicToc implements TicTocInterface {
       throw Exception('locationTime is not allowed to be null');
     }
     final DateTime networkDateTime = locationTime.dateTime;
-    offset =
-        networkDateTime.difference(DateTime.now()).inMilliseconds;
+    offset = networkDateTime.difference(DateTime.now()).inMilliseconds;
     _synced = true;
 
     return now();


### PR DESCRIPTION
## `ntpOffset`과 `worldTimeApiOffset`을 offset으로 통일합니다
- native에서는 `ntpOffset`, web에서는 `worldTimeApiOffset`으로 사용중인데, 이들을 `offset`으로 통일하여 인터페이스에 부합하도록 합니다!