### PR TITLE
fix: MockTictoc's offset override

### DIFF
--- a/packages/tictoc_test/lib/src/mock_tictoc.dart
+++ b/packages/tictoc_test/lib/src/mock_tictoc.dart
@@ -11,6 +11,7 @@ class MockTictoc implements TicTocInterface {
     _localTime = localTime ?? DateTime.now();
   }
 
+  @override
   late final int offset;
   bool _synced = false;
   late final DateTime _localTime;


### PR DESCRIPTION
MockTictoc의 offset에 override가 명시되지 않아 linter 오류가 나던 것을 수정합니다.